### PR TITLE
Critical: Item not fit unrotated yet inserted

### DIFF
--- a/Packer.php
+++ b/Packer.php
@@ -270,7 +270,7 @@
           $remainingWeight -= $itemToPack->getWeight();
 
           if ($fitsRotatedGap < 0 ||
-              $fitsSameGap <= $fitsRotatedGap ||
+              ($fitsSameGap >= 0 && $fitsSameGap <= $fitsRotatedGap) ||
               (!$aItems->isEmpty() && $aItems->top() == $itemToPack && $remainingLength >= 2 * $itemLength)) {
             $this->logger->log(LogLevel::DEBUG,  "fits (better) unrotated");
             $remainingLength -= $itemLength;


### PR DESCRIPTION
If an item doesn't fit unrotated it's inserted that direction since $fitsSameGap < $fitsRotatedGap. Creates an impossible scenario. Fixed bug but did not update unit tests.

Found bug using a box of 23x21x17 with an item of 16x23x10
