### PR TITLE
Basic orientation optimization

### DIFF
--- a/BoxList.php
+++ b/BoxList.php
@@ -13,6 +13,11 @@
    */
   class BoxList extends \SplMinHeap {
 
+    public function insert($value) {
+      $value = Orient::box($value);
+      parent::insert($value);
+    }
+  	
     /**
      * Compare elements in order to place them correctly in the heap while sifting up.
      * @see \SplMinHeap::compare()

--- a/ItemList.php
+++ b/ItemList.php
@@ -13,6 +13,11 @@
    */
   class ItemList extends \SplMaxHeap {
 
+    public function insert($value) {
+      $value = Orient::item($value);
+      parent::insert($value);
+    }
+  	
     /**
      * Compare elements in order to place them correctly in the heap while sifting up.
      * @see \SplMaxHeap::compare()

--- a/Orient.php
+++ b/Orient.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Box|Item orientation optimizer
+ * @package BoxPacker
+ * @author Kevin Farley / eCommunities
+ */
+  namespace DVDoug\BoxPacker;
+
+  /**
+   * Orient Static Class
+   * @author Kevin Farley / eCommunities
+   * @package BoxPacker
+   */
+  class Orient {
+    
+    /**
+     * Optimize an box's orientation
+     * @static 
+     * @param box $box
+     * @return box
+     */
+    public static function box(box $box) {
+    	// Ensure the proper methods exist for orientation reset, otherwise skip it.
+    	// FIXME: This can be eliminated in the future once the box interface is updated to include these methods (NB: which would break backward compatibility)
+    	if (!method_exists($box,'setInnerWidth') || !method_exists($box,'setInnerLength') || !method_exists($box,'setInnerDepth') || !method_exists($box,'setOuterWidth') || !method_exists($box,'setOuterLength') || !method_exists($box,'setOuterDepth')) {
+    		return $box;
+    	}
+    	
+    	// Extract the basic dimensions, break early if already oriented optimally
+    	if ($box->getOuterLength() <= $box->getOuterWidth() && $box->getOuterWidth() <= $box->getOuterDepth()) { 
+    		return $box;
+    	} else {
+    		$outer = array($box->getOuterLength(), $box->getOuterWidth(), $box->getOuterDepth());
+    		$inner = array($box->getInnerLength(), $box->getInnerWidth(), $box->getInnerDepth());
+    	}
+    		
+    	// Orient the box so that the longest edge is placed in depth, and then the smallest in length
+    	array_multisort($outer, $inner);
+    		
+    	// Reset the box dimensions
+    	$box->setOuterLength($outer[0]);
+    	$box->setOuterWidth($outer[1]);
+    	$box->setOuterDepth($outer[2]);
+    		
+    	$box->setInnerLength($inner[0]);
+    	$box->setInnerWidth($inner[1]);
+    	$box->setInnerDepth($inner[2]);
+
+    	return $box;
+    }
+    
+    /**
+     * Optimize an item's orientation 
+     * @static
+     * @param item $item
+     * @return item
+     */
+    public static function item($item) {
+    	// Ensure the proper methods exist for orientation reset, otherwise skip it.
+    	// FIXME: This can be eliminated in the future once the item interface is updated to include these methods (NB: which would break backward compatibility)
+    	if (!method_exists($item,'setWidth') || !method_exists($item,'setLength') || !method_exists($item,'setDepth')) {
+    		return $item;
+    	}
+    	
+    	// Extract the basic dimensions, break early if already oriented optimally
+    	if ($item->getLength() <= $item->getWidth() && $item->getWidth() <= $item->getDepth()) { 
+    		return $item;
+    	} else {
+    		$measures = array($item->getLength(), $item->getWidth(), $item->getDepth());
+    	}
+    	
+    	// Orient the item so that the longest edge is placed in depth, and then the smallest in length
+    	sort($measures);
+    	
+    	// Reset the item dimensions
+    	$item->setLength($measures[0]);
+    	$item->setWidth($measures[1]);
+    	$item->setDepth($measures[2]);
+    	
+    	return $item;
+    }
+    
+  }

--- a/Packer.php
+++ b/Packer.php
@@ -270,7 +270,7 @@
           $remainingWeight -= $itemToPack->getWeight();
 
           if ($fitsRotatedGap < 0 ||
-              $fitsSameGap <= $fitsRotatedGap ||
+              ($fitsSameGap >= 0 && $fitsSameGap <= $fitsRotatedGap) ||
               (!$aItems->isEmpty() && $aItems->top() == $itemToPack && $remainingLength >= 2 * $itemLength)) {
             $this->logger->log(LogLevel::DEBUG,  "fits (better) unrotated");
             $remainingLength -= $itemLength;

--- a/Packer.php
+++ b/Packer.php
@@ -47,6 +47,7 @@
      * @param int  $aQty
      */
     public function addItem(Item $aItem, $aQty = 1) {
+      $aItem = Orient::item($aItem);
       for ($i = 0; $i < $aQty; $i++) {
         $this->items->insert($aItem);
       }
@@ -77,6 +78,7 @@
      * @param Box $aBox
      */
     public function addBox(Box $aBox) {
+      $abox = Orient::box($aBox);
       $this->boxes->insert($aBox);
       $this->logger->log(LogLevel::INFO, "added box {$aBox->getReference()}");
     }

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7",
-        "monolog/monolog": "~1.3"
+        "phpunit/phpunit": "~4.3",
+        "monolog/monolog": "~1.11"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
These additions provide basic box rotation so that the standard orientation of all boxes and items are in the same direction.  Boxes|Items are oriented when added to the packer using addItem(), or addBox(), or when added to a list.  The optimization standardizes orientation so that the longest edge is set as the depth, and then the shortest edge is set to the height (length in your taxonomy).

The additions have been made so as to remain backward compatible with existing implementations.  Each orientation method will first verify the existence of the required setter methods before attempting to continue, and will simply return the unchanged cuboid in it's original form when they do not exist.