### PR TITLE
Change describing property for item from description -> name

### DIFF
--- a/Box.php
+++ b/Box.php
@@ -12,12 +12,22 @@
    * @package BoxPacker
    */
   interface Box {
+  	
+  	const TYPE_ENVELOPE		= 'envelope';
+  	const TYPE_BOX			= 'box';
 
     /**
      * Reference for box type (e.g. SKU or description)
      * @return string
      */
     public function getReference();
+    
+    
+    /**
+     * Is the Box an envelope or a box
+     * @return string
+     */
+    public function getType();
 
     /**
      * Outer width in mm
@@ -72,5 +82,17 @@
      * @return int
      */
     public function getMaxWeight();
+    
+    /**
+     * Returns true if the Box is a box
+     * @return bool
+     */
+    public function isTypeBox();
+    
+    /**
+     * Returns true if the Box is an envelope
+     * @return bool
+     */
+    public function isTypeEnvelope();
 
   }

--- a/Item.php
+++ b/Item.php
@@ -17,7 +17,7 @@
      * Item SKU etc
      * @return string
      */
-    public function getDescription();
+    public function getName();
 
     /**
      * Item width in mm

--- a/Packer.php
+++ b/Packer.php
@@ -50,7 +50,7 @@
       for ($i = 0; $i < $aQty; $i++) {
         $this->items->insert($aItem);
       }
-      $this->logger->log(LogLevel::INFO, "added {$aQty} x {$aItem->getDescription()}");
+      $this->logger->log(LogLevel::INFO, "added {$aQty} x {$aItem->getName()}");
     }
 
     /**
@@ -138,7 +138,7 @@
 
         //Check iteration was productive
         if ($packedBoxesIteration->isEmpty()) {
-          throw new \RuntimeException('Item ' . $this->items->top()->getDescription() . ' is too large to fit into any box');
+          throw new \RuntimeException('Item ' . $this->items->top()->getName() . ' is too large to fit into any box');
         }
 
         //Find best box of iteration, and remove packed items from unpacked list
@@ -254,7 +254,7 @@
           break;
         }
 
-        $this->logger->log(LogLevel::DEBUG,  "evaluating item {$itemToPack->getDescription()}");
+        $this->logger->log(LogLevel::DEBUG,  "evaluating item {$itemToPack->getName()}");
         $this->logger->log(LogLevel::DEBUG,  "remaining width: {$remainingWidth}, length: {$remainingLength}, depth: {$remainingDepth}");
         $this->logger->log(LogLevel::DEBUG,  "layerWidth: {$layerWidth}, layerLength: {$layerLength}, layerDepth: {$layerDepth}");
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -65,8 +65,8 @@
 
   class TestItem implements Item {
 
-    public function __construct($aDescription,$aWidth,$aLength,$aDepth,$aWeight) {
-      $this->description = $aDescription;
+    public function __construct($aName,$aWidth,$aLength,$aDepth,$aWeight) {
+      $this->name = $aName;
       $this->width = $aWidth;
       $this->length = $aLength;
       $this->depth = $aDepth;
@@ -74,8 +74,8 @@
       $this->volume = $this->width * $this->length * $this->depth;
     }
 
-    public function getDescription() {
-      return $this->description;
+    public function getName() {
+      return $this->name;
     }
 
     public function getWidth() {


### PR DESCRIPTION
In our system, an item has both a name and a description. The name is a short name/describing title, and the description is a longer describing text.