### PR TITLE
Calculate weight on construct of packedBox

### DIFF
--- a/PackedBox.php
+++ b/PackedBox.php
@@ -139,6 +139,7 @@
       $this->remainingLength = $aRemainingLength;
       $this->remainingDepth = $aRemainingDepth;
       $this->remainingWeight = $aRemainingWeight;
+      $this->weight = $this->getWeight();
     }
 
   }


### PR DESCRIPTION
I was testing with the library and when all fitted in one box, the weight was still null. Only after changing into redistribution weight mode the first box got a weight set, but the second weight was still null. This change does fix that behavior, on construct of the PackedBox the weight is also set just to make sure it is available.

Before:

```
PackedBoxList {#2030 ▼
  #meanWeight: null
  #weightVariance: null
  heap: array:2 [▼
    1 => PackedBox {#2045 ▼
      #box: XBox {#2024 ▶}
      #items: ItemList {#2044 ▶}
      #weight: 1.0
      #remainingWidth: 40
      #remainingLength: 30.0
      #remainingDepth: 20
      #remainingWeight: 9.0
    }
    0 => PackedBox {#2053 ▼
      #box: XBox {#2025 ▶}
      #items: ItemList {#2052 ▶}
      #weight: null
      #remainingWidth: 80
      #remainingLength: 30.0
      #remainingDepth: 40
      #remainingWeight: 0.6
    }
  ]
}
```
After:
```
PackedBoxList {#2030 ▼
  #meanWeight: null
  #weightVariance: null
  heap: array:2 [▼
    1 => PackedBox {#2045 ▼
      #box: XBox {#2024 ▶}
      #items: ItemList {#2044 ▶}
      #weight: 1.0
      #remainingWidth: 40
      #remainingLength: 30.0
      #remainingDepth: 20
      #remainingWeight: 9.0
    }
    0 => PackedBox {#2053 ▼
      #box: XBox {#2025 ▶}
      #items: ItemList {#2052 ▶}
      #weight: 1.4
      #remainingWidth: 80
      #remainingLength: 30.0
      #remainingDepth: 40
      #remainingWeight: 0.6
    }
  ]
}
```