### PR TITLE
Attempt to fix #30 (integer overflow issues when there are large volume differences)

### DIFF
--- a/BoxList.php
+++ b/BoxList.php
@@ -6,19 +6,30 @@
  */
   namespace DVDoug\BoxPacker;
 
+  define('MAX_32BIT_INT', pow(2,31) - 1);
+
   /**
    * List of boxes available to put items into, ordered by volume
    * @author Doug Wright
    * @package BoxPacker
    */
   class BoxList extends \SplMinHeap {
+    private $min =  PHP_INT_MAX;
+    private $max =  0;
+
+    public function insert($value) {
+      $this->min = min($this->min, $value->getInnerVolume());
+      $this->max = max($this->max, $value->getInnerVolume());
+      parent::insert($value);
+    }
 
     /**
      * Compare elements in order to place them correctly in the heap while sifting up.
      * @see \SplMinHeap::compare()
      */
     public function compare($aBoxA, $aBoxB) {
-      return $aBoxB->getInnerVolume() - $aBoxA->getInnerVolume();
+      // Scale our result compared to our max and min volumes to never have integer overflow issues
+      return floor((($aBoxB->getInnerVolume() - $aBoxA->getInnerVolume()) / ($this->max - $this->min)) * MAX_32BIT_INT);
     }
 
   }

--- a/tests/BoxListTest.php
+++ b/tests/BoxListTest.php
@@ -26,4 +26,76 @@
       }
       self::assertEquals(array($box1,$box3,$box2), $sorted);
     }
+
+    function testCompareWithBigDifference() {
+      // If the difference in volume is greater than 2^31 -1, SplHeap's compare() overflows
+      // the integer and can't cope. Check we're handling big differences okay.
+      $box1 = new TestBox('Small', 21, 21, 3, 1, 20, 20, 2, 100);
+      $box2 = new TestBox('Large', 1301, 1301, 1301, 1, 1300, 1300, 1300, 1000);
+      $box3 = new TestBox('Medium', 101, 101, 11, 5, 100, 100, 10, 500);
+
+      $list = new BoxList;
+      $list->insert($box1);
+      $list->insert($box2);
+      $list->insert($box3);
+
+      $sorted = [];
+      while (!$list->isEmpty()) {
+        $sorted[] = $list->extract();
+      }
+      self::assertEquals(array($box1,$box3,$box2), $sorted);
+    }
+
+    function testCompareWithBigDifferenceNotAffectedByInsertOrder() {
+      // If the difference in volume is greater than 2^31 -1, SplHeap's compare() overflows
+      // the integer and can't cope. Check we're handling big differences okay and that it
+      // works with different sort orders
+      $box1 = new TestBox('Small', 21, 21, 3, 1, 20, 20, 2, 100);
+      $box2 = new TestBox('Large', 1301, 1301, 1301, 1, 1300, 1300, 1300, 1000);
+      $box3 = new TestBox('Medium', 101, 101, 11, 5, 100, 100, 10, 500);
+
+      $list = new BoxList;
+      $list->insert($box3);
+      $list->insert($box2);
+      $list->insert($box1);
+
+      $sorted = [];
+      while (!$list->isEmpty()) {
+        $sorted[] = $list->extract();
+      }
+      self::assertEquals(array($box1,$box3,$box2), $sorted);
+
+      $list = new BoxList;
+      $list->insert($box2);
+      $list->insert($box1);
+      $list->insert($box3);
+
+      $sorted = [];
+      while (!$list->isEmpty()) {
+        $sorted[] = $list->extract();
+      }
+      self::assertEquals(array($box1,$box3,$box2), $sorted);
+    }
+
+    function testCompareWithBigAndSmallDifference() {
+      // If the difference in volume is greater than 2^31 -1, SplHeap's compare() overflows
+      // the integer and can't cope. Check we're handling big differences okay when there's
+      // also an item that's almost the same size as the one that's 2^31 bigger than others
+      $box1 = new TestBox('Small', 21, 21, 3, 1, 20, 20, 2, 100);
+      $box2 = new TestBox('Large', 1301, 1301, 1301, 1, 1300, 1300, 1300, 1000);
+      $box3 = new TestBox('Larger', 1302, 1302, 1302, 1, 1301, 1301, 1301, 1000);
+      $box4 = new TestBox('Medium', 101, 101, 11, 5, 100, 100, 10, 500);
+
+      $list = new BoxList;
+      $list->insert($box1);
+      $list->insert($box2);
+      $list->insert($box3);
+      $list->insert($box4);
+
+      $sorted = [];
+      while (!$list->isEmpty()) {
+        $sorted[] = $list->extract();
+      }
+      self::assertEquals(array($box1,$box4,$box2,$box3), $sorted);
+    }
   }


### PR DESCRIPTION
This works for me and passes the tests I wrote. A 1.5m cubed box is now considered to be larger than a Jiffy bag envelope and is sorted correctly, which is always reassuring.