### PR TITLE
Update Packer.php so that you can pass in a Logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 # omitting "script:" will default to phpunit


### PR DESCRIPTION
Currently no way of using Dependancy Injection to override the default NullLogger, this change will allow you to pass in a Logger implementation that uses the Psr Log LoggerInterface.

As you're using the LoggerAwareTrait we don't need to specifically set it using `$this->logger = new NullLogger();` and this now uses the appropriate `setLogger()` method exposed by the Trait.

I'm currently using the package in Laravel, so I can now do:

```
$packer = new DVDoug\BoxPacker\Packer(Log::getMonolog());
```

Thanks for your time & effor on this great package!