### PR TITLE
Documentation - in getting-started and advanced-usage, $packedItems v…

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -46,7 +46,7 @@ Example
 
         // assuming packing already took place
         foreach ($packedBoxes as $packedBox) {
-            $packedItems = $packedBox->getItems();
+            $packedItems = $packedBox->getPackedItems();
             foreach ($packedItems as $packedItem) { // $packedItem->getItem() is your own item object
                 echo $packedItem->getItem()->getDescription() .  ' was packed at co-ordinate ' ;
                 echo '(' . $packedItem->getX() . ', ' . $packedItem->getY() . ', ' . $packedItem->getZ() . ') with ';

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -58,7 +58,7 @@ Packing a set of items into a given set of box types
             echo "The combined weight of this box and the items inside it is {$packedBox->getWeight()}g" . PHP_EOL;
 
             echo "The items in this box are:" . PHP_EOL;
-            $packedItems = $packedBox->getItems();
+            $packedItems = $packedBox->getPackedItems();
             foreach ($packedItems as $packedItem) { // $packedItem->getItem() is your own item object, in this case TestItem
                 echo $packedItem->getItem()->getDescription() . PHP_EOL;
             }


### PR DESCRIPTION
…ars were incorrectly using getItems() instead of getPackedItems() - this means that instead of getting back the PackedItemList (including details like the X/Y positioning), the ItemList was being returned instead (containing just the Item information)