### PR TITLE
new Boxlist fromArray method

### DIFF
--- a/src/BoxList.php
+++ b/src/BoxList.php
@@ -43,8 +43,8 @@ class BoxList implements IteratorAggregate
      */
     public static function fromArray(array $boxes, bool $preSorted = false): self
     {
-        $list           = new static();
-        $list->list     = $boxes;
+        $list = new static();
+        $list->list = $boxes;
         $list->isSorted = $preSorted;
 
         return $list;

--- a/src/BoxList.php
+++ b/src/BoxList.php
@@ -35,6 +35,22 @@ class BoxList implements IteratorAggregate
     private $isSorted = false;
 
     /**
+     * Do a bulk create.
+     *
+     * @param Box[] $boxes
+     *
+     * @return BoxList
+     */
+    public static function fromArray(array $boxes, bool $preSorted = false): self
+    {
+        $list           = new static();
+        $list->list     = $boxes;
+        $list->isSorted = $preSorted;
+
+        return $list;
+    }
+
+    /**
      * @return Traversable|Box[]
      */
     public function getIterator(): Traversable

--- a/tests/BoxListTest.php
+++ b/tests/BoxListTest.php
@@ -37,7 +37,7 @@ class BoxListTest extends TestCase
     }
 
     /**
-     * Test that creating an instance using the fromArray method will sort the boxes by default
+     * Test that creating an instance using the fromArray method will sort the boxes by default.
      */
     public function testFromArray(): void
     {
@@ -52,7 +52,7 @@ class BoxListTest extends TestCase
     }
 
     /**
-     * Test that creating an instance using the fromArray method can skip sorting the boxes
+     * Test that creating an instance using the fromArray method can skip sorting the boxes.
      */
     public function testFromArrayPreSorted(): void
     {

--- a/tests/BoxListTest.php
+++ b/tests/BoxListTest.php
@@ -37,6 +37,36 @@ class BoxListTest extends TestCase
     }
 
     /**
+     * Test that creating an instance using the fromArray method will sort the boxes by default
+     */
+    public function testFromArray(): void
+    {
+        $box1 = new TestBox('Small', 21, 21, 3, 1, 20, 20, 2, 100);
+        $box2 = new TestBox('Large', 201, 201, 21, 1, 200, 200, 20, 1000);
+        $box3 = new TestBox('Medium', 101, 101, 11, 5, 100, 100, 10, 500);
+
+        $list = BoxList::fromArray([$box1, $box2, $box3]);
+
+        $sorted = iterator_to_array($list, false);
+        self::assertEquals([$box1, $box3, $box2], $sorted);
+    }
+
+    /**
+     * Test that creating an instance using the fromArray method can skip sorting the boxes
+     */
+    public function testFromArrayPreSorted(): void
+    {
+        $box1 = new TestBox('Small', 21, 21, 3, 1, 20, 20, 2, 100);
+        $box2 = new TestBox('Large', 201, 201, 21, 1, 200, 200, 20, 1000);
+        $box3 = new TestBox('Medium', 101, 101, 11, 5, 100, 100, 10, 500);
+
+        $list = BoxList::fromArray([$box1, $box2, $box3], true);
+
+        $sorted = iterator_to_array($list, false);
+        self::assertEquals([$box1, $box2, $box3], $sorted);
+    }
+
+    /**
      * Test that when there are spatially identical boxes that hold the same contents, prefer the one that weighs least.
      */
     public function testPickLighterBoxAllElseEqual(): void


### PR DESCRIPTION
Adds a fromArray method to the BoxList object, making it possible to create preSorted boxlists that will skip the internal compare method.