### PR TITLE
Add ability to clear the empty box cache

### DIFF
--- a/src/OrientatedItemFactory.php
+++ b/src/OrientatedItemFactory.php
@@ -256,4 +256,13 @@ class OrientatedItemFactory implements LoggerAwareInterface
 
         return $permutations;
     }
+
+    /**
+     * Clear the empty box cache. Useful is part of a long running 
+     * process to prevent memory leaks.
+     */
+    public static function clearEmptyBoxCache() : void
+    {
+        self::$emptyBoxCache = [];
+    }
 }


### PR DESCRIPTION
Hi! 

Thank you very much for sharing this library. 

I've traced down a memory leak in a long running process to the emptyBoxCache in the OrientatedItemFactory. 

What I've got here is far from an ideal solution; but it does allow a developer to clear the cache. I'm not sure if there is a sensible position within the code to clear the cache (perhaps at the end of the pack() method), but this does at least allow a developer to control the cache size.

Tim