### PR TITLE
add permutations key prefix

### DIFF
--- a/src/OrientatedItemFactory.php
+++ b/src/OrientatedItemFactory.php
@@ -229,17 +229,17 @@ class OrientatedItemFactory implements LoggerAwareInterface
         $l = $item->getLength();
         $d = $item->getDepth();
 
-        $permutations[$w . $l . $d] = [$w, $l, $d];
+        $permutations['wld' . $w . $l . $d] = [$w, $l, $d];
 
         if ($item->getAllowedRotations() > 1) { //simple 2D rotation
-            $permutations[$l . $w . $d] = [$l, $w, $d];
+            $permutations['lwd' . $l . $w . $d] = [$l, $w, $d];
         }
 
         if ($item->getAllowedRotations() === Item::ROTATION_BEST_FIT) { //add 3D rotation if we're allowed
-            $permutations[$w . $d . $l] = [$w, $d, $l];
-            $permutations[$l . $d . $w] = [$l, $d, $w];
-            $permutations[$d . $w . $l] = [$d, $w, $l];
-            $permutations[$d . $l . $w] = [$d, $l, $w];
+            $permutations['wdl' . $w . $d . $l] = [$w, $d, $l];
+            $permutations['ldw' . $l . $d . $w] = [$l, $d, $w];
+            $permutations['dwl'. $d . $w . $l] = [$d, $w, $l];
+            $permutations['dlw' .$d . $l . $w] = [$d, $l, $w];
         }
 
         return $permutations;

--- a/tests/OrientatedItemFactoryTest.php
+++ b/tests/OrientatedItemFactoryTest.php
@@ -15,6 +15,17 @@ use PHPUnit\Framework\TestCase;
 
 class OrientatedItemFactoryTest extends TestCase
 {
+    public function testAllRotationsCount(): void
+    {
+        $box = new TestBox('Box', PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX, 0, PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX);
+        $factory = new OrientatedItemFactory($box);
+
+        $item = new TestItem('Test', 4, 44, 41, 4, TestItem::ROTATION_BEST_FIT);
+        $orientations = $factory->getPossibleOrientations($item, null, $box->getInnerWidth(), $box->getInnerLength(), $box->getInnerDepth(), 0, 0, 0, new PackedItemList());
+
+        self::assertCount(6, $orientations);
+    }
+
     public function testAllRotations(): void
     {
         $box = new TestBox('Box', PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX, 0, PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX, PHP_INT_MAX);


### PR DESCRIPTION
When box item sides looks like 44, 4, 41 and Item::ROTATION_BEST_FIT expected 6 permutations, but rotations 4 44 41 and 44 4 41 with two different values can replace each other.