### PR TITLE
feature: add timeout feature

### DIFF
--- a/src/DefaultTimeoutChecker.php
+++ b/src/DefaultTimeoutChecker.php
@@ -11,6 +11,8 @@ namespace DVDoug\BoxPacker;
 
 use DVDoug\BoxPacker\Exception\TimeoutException;
 
+use function microtime;
+
 class DefaultTimeoutChecker implements TimeoutChecker
 {
     private float $startTime;
@@ -21,12 +23,12 @@ class DefaultTimeoutChecker implements TimeoutChecker
 
     public function start(?float $startTime = null): void
     {
-        $this->startTime = $startTime ?? \microtime(true);
+        $this->startTime = $startTime ?? microtime(true);
     }
 
     public function throwOnTimeout(?float $currentTime = null, string $message = 'Exceeded the timeout'): void
     {
-        $spentTime = ($currentTime ?? \microtime(true)) - $this->startTime;
+        $spentTime = ($currentTime ?? microtime(true)) - $this->startTime;
         $isTimeout = $spentTime >= $this->timeout;
         if ($isTimeout) {
             throw new TimeoutException($message, $spentTime, $this->timeout);

--- a/src/DefaultTimeoutChecker.php
+++ b/src/DefaultTimeoutChecker.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker;
+
+use DVDoug\BoxPacker\Exception\TimeoutException;
+
+class DefaultTimeoutChecker implements TimeoutChecker
+{
+    private float $startTime;
+
+    public function __construct(readonly private float $timeout)
+    {
+    }
+
+    public function start(?float $startTime = null): void
+    {
+        $this->startTime = $startTime ?? \microtime(true);
+    }
+
+    public function throwOnTimeout(?float $currentTime = null, string $message = 'Exceeded the timeout'): void
+    {
+        $spentTime = ($currentTime ?? \microtime(true)) - $this->startTime;
+        $isTimeout = $spentTime >= $this->timeout;
+        if ($isTimeout) {
+            throw new TimeoutException($message, $spentTime, $this->timeout);
+        }
+    }
+}

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception used when the timeout occurred
+ */
+class TimeoutException extends RuntimeException
+{
+    public function __construct(string $message, private readonly float $spentTime, private readonly float $timeout)
+    {
+        parent::__construct($message);
+    }
+
+    public function getTimeout(): float
+    {
+        return $this->timeout;
+    }
+
+    public function getSpentTime(): float
+    {
+        return $this->spentTime;
+    }
+}

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -12,7 +12,7 @@ namespace DVDoug\BoxPacker\Exception;
 use RuntimeException;
 
 /**
- * Exception used when the timeout occurred
+ * Exception used when the timeout occurred.
  */
 class TimeoutException extends RuntimeException
 {

--- a/src/TimeoutChecker.php
+++ b/src/TimeoutChecker.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker;
+
+use DVDoug\BoxPacker\Exception\TimeoutException;
+
+interface TimeoutChecker
+{
+    public function __construct(float $timeout);
+
+    public function start(?float $startTime = null): void;
+
+    /**
+     * @throws TimeoutException
+     */
+    public function throwOnTimeout(?float $currentTime = null, string $message = 'Exceeded the timeout'): void;
+}

--- a/src/WeightRedistributor.php
+++ b/src/WeightRedistributor.php
@@ -38,7 +38,8 @@ class WeightRedistributor implements LoggerAwareInterface
     public function __construct(
         private readonly BoxList $boxes,
         private readonly PackedBoxSorter $packedBoxSorter,
-        private WeakMap $boxQuantitiesAvailable
+        private WeakMap $boxQuantitiesAvailable,
+        private readonly ?TimeoutChecker $timeoutChecker,
     ) {
         $this->logger = new NullLogger();
     }
@@ -106,6 +107,7 @@ class WeightRedistributor implements LoggerAwareInterface
         $underWeightBoxItems = $underWeightBox->items->asItemArray();
 
         foreach ($overWeightBoxItems as $key => $overWeightItem) {
+            $this->timeoutChecker?->throwOnTimeout();
             if (!self::wouldRepackActuallyHelp($overWeightBoxItems, $overWeightItem, $underWeightBoxItems, $targetWeight)) {
                 continue; // moving this item would harm more than help
             }


### PR DESCRIPTION
#620
usage (see tests/PackerTest.php testTimeoutException):
```php
$packer = new Packer();
$packer->setTimeoutChecker(new DefaultTimeoutChecker(3.0));

for ($i = 0; $i < 100; ++$i) {
    $box = new TestBox(
        reference: 'box ' . $i,
        outerWidth: $i * 10,
        outerLength: $i * 10,
        outerDepth: $i * 10,
        emptyWeight: 1,
        innerWidth: $i * 10,
        innerLength: $i * 10,
        innerDepth: $i * 10,
        maxWeight: 10000
    );
    $packer->addBox($box);
}

$item = new TestItem(
    description: 'item 1',
    width: 100,
    length: 100,
    depth: 100,
    weight: 100,
    allowedRotation: Rotation::BestFit
);
$packer->addItem($item, 500);

// throw the TimeoutException
$packer->pack();
```