### PR TITLE
allow set default objects to Packer

### DIFF
--- a/src/Packer.php
+++ b/src/Packer.php
@@ -48,14 +48,18 @@ class Packer implements LoggerAwareInterface
 
     protected ?TimeoutChecker $timeoutChecker = null;
 
-    public function __construct()
-    {
-        $this->items = new ItemList();
-        $this->boxes = new BoxList();
-        $this->packedBoxSorter = new DefaultPackedBoxSorter();
+    public function __construct(
+        ItemList $items = new ItemList(),
+        BoxList $boxes = new BoxList(),
+        PackedBoxSorter $packedBoxSorter = new DefaultPackedBoxSorter(),
+        LoggerInterface $logger = new NullLogger(),
+    ) {
+        $this->items = $items;
+        $this->boxes = $boxes;
+        $this->packedBoxSorter = $packedBoxSorter;
         $this->boxQuantitiesAvailable = new WeakMap();
 
-        $this->logger = new NullLogger();
+        $this->logger = $logger;
     }
 
     public function setLogger(LoggerInterface $logger): void


### PR DESCRIPTION
use case:
```php
use DVDoug\BoxPacker\Packer;
use DVDoug\BoxPacker\BoxList;

$packer = new Packer(boxes: new BoxList(new CustomBoxSorter()));
```

Currently we have to create our own Packer class and extend the original one in order to set custom BoxSorter. New possibility allows us to set the params through the constructor.