### PR TITLE
Addressed several deprecations for PHP 8.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [3.x - Unreleased] - 2023-xx-xx
 
+## [3.12.2] - 2025-07-05
+### Fixed
+- Addressed several deprecations for PHP 8.4.
+
 ## [3.12.1] - 2023-12-02
 ### Fixed
 - Restored ability to copy/paste the samples from the docs into a non-dev installation

--- a/src/BoxList.php
+++ b/src/BoxList.php
@@ -28,7 +28,7 @@ class BoxList implements IteratorAggregate
 
     private BoxSorter $sorter;
 
-    public function __construct(BoxSorter $sorter = null)
+    public function __construct(?BoxSorter $sorter = null)
     {
         $this->sorter = $sorter ?: new DefaultBoxSorter();
     }

--- a/src/ItemList.php
+++ b/src/ItemList.php
@@ -43,7 +43,7 @@ class ItemList implements Countable, IteratorAggregate
      */
     private ?bool $hasConstrainedItems = null;
 
-    public function __construct(ItemSorter $sorter = null)
+    public function __construct(?ItemSorter $sorter = null)
     {
         $this->sorter = $sorter ?: new DefaultItemSorter();
     }

--- a/src/PackedBoxList.php
+++ b/src/PackedBoxList.php
@@ -34,7 +34,7 @@ class PackedBoxList implements IteratorAggregate, Countable, JsonSerializable
 
     private PackedBoxSorter $sorter;
 
-    public function __construct(PackedBoxSorter $sorter = null)
+    public function __construct(?PackedBoxSorter $sorter = null)
     {
         $this->sorter = $sorter ?: new DefaultPackedBoxSorter();
     }


### PR DESCRIPTION
Upgrading to library v4.x isn't always an option, but projects are already running on PHP 8.4.
That's why it's crucial to fix the bugs that cause these failures.