### PR TITLE
Enable the ability to force pack items together

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ BoxPacker is licensed under the `MIT license`_.
     positional-information
     limited-supply-boxes
     custom-constraints
+    linked-items
     used-remaining-space
     all-permutations
     changelog

--- a/docs/linked-items.rst
+++ b/docs/linked-items.rst
@@ -1,0 +1,99 @@
+Linked items
+============
+
+In some scenarios you may have two or more items that must always be packed into the same box — for example, a product and its
+mandatory accessory, or a set of items that are sold together and must ship as a unit.
+
+To express this constraint, implement the ``BoxPacker\LinkedItem`` interface on your item class. The interface extends ``BoxPacker\Item``
+and adds a single method:
+
+.. code-block:: php
+
+    public function getLinkedItemGroup(): string;
+
+Any items that return the **same non-empty string** from this method are treated as a linked group: the packer guarantees
+they will all end up in the same ``PackedBox``.
+
+.. code-block:: php
+
+    <?php
+        use DVDoug\BoxPacker\LinkedItem;
+        use DVDoug\BoxPacker\Rotation;
+
+        class MyLinkedItem implements LinkedItem
+        {
+            public function __construct(
+                private readonly string $description,
+                private readonly int $width,
+                private readonly int $length,
+                private readonly int $depth,
+                private readonly int $weight,
+                private readonly Rotation $allowedRotation,
+                private readonly string $linkedItemGroup,
+            ) {}
+
+            // ... standard Item methods ...
+
+            public function getLinkedItemGroup(): string
+            {
+                return $this->linkedItemGroup;
+            }
+        }
+
+        $packer = new Packer();
+        $packer->addBox(new MyBox(...));
+
+        // item1 and item2 share the same group identifier and will always be packed together
+        $packer->addItem(new MyLinkedItem('Product', ..., linkedItemGroup: 'order-line-42'));
+        $packer->addItem(new MyLinkedItem('Accessory', ..., linkedItemGroup: 'order-line-42'));
+
+        $packedBoxes = $packer->pack();
+
+Quantities
+----------
+
+If you call ``addItem($linkedItem, qty: N)`` for a ``LinkedItem``, all N inserted instances share the same group
+identifier and are therefore all considered part of the same linked group. They will all be packed into the same box.
+
+.. code-block:: php
+
+    $packer->addItem(new MyLinkedItem('Part', ..., linkedItemGroup: 'kit-99'), 4);
+    // All 4 instances are part of group 'kit-99' and will always ship together
+
+Non-adjacency
+-------------
+
+The linked-group guarantee is about **box assignment only**. Items in a linked group will be in the same ``PackedBox``,
+but the packer does **not** guarantee that they are physically adjacent or contiguous inside that box. If you additionally
+need adjacency, implement :doc:`custom-constraints` alongside ``LinkedItem``.
+
+Behaviour when a linked group cannot fit
+-----------------------------------------
+
+If no available box can hold all members of a linked group simultaneously, the packer treats the whole group as
+unpackable — the same way it handles any individual item that is too large to fit. The behaviour is controlled by
+``throwOnUnpackableItem()``:
+
+- ``throwOnUnpackableItem(true)`` (the default) — throws ``NoBoxesAvailableException``.
+- ``throwOnUnpackableItem(false)`` — the group is skipped; all remaining packable items (including other linked groups
+  that *can* fit) are still packed.
+
+Weight redistribution
+---------------------
+
+Linked groups are preserved during the automatic :doc:`weight-distribution` pass. The redistributor skips all linked
+group members entirely — they are never moved between boxes during weight balancing. This ensures group integrity is
+always maintained at the cost of potentially less optimal weight distribution.
+
+Invalid group identifiers
+--------------------------
+
+An empty string (``''``) is not a valid group identifier and will cause an ``\InvalidArgumentException`` when the item
+is added to the packer. Use a non-empty string such as a UUID, order-line ID, or SKU combination.
+
+Performance note
+----------------
+
+As with :doc:`custom-constraints`, only implement ``LinkedItem`` on item classes that genuinely need this feature. The
+packer has to perform additional group-completeness checks for every candidate box when linked items are present, which
+adds a small overhead compared to packing ordinary items.

--- a/src/ItemList.php
+++ b/src/ItemList.php
@@ -11,6 +11,7 @@ namespace DVDoug\BoxPacker;
 
 use ArrayIterator;
 use Countable;
+use InvalidArgumentException;
 use IteratorAggregate;
 use Traversable;
 
@@ -41,6 +42,11 @@ class ItemList implements Countable, IteratorAggregate
 
     private ?bool $hasNoRotationItems = null;
 
+    /**
+     * @var array<string, int>
+     */
+    private array $linkedGroupCounts = [];
+
     public function __construct(private readonly ItemSorter $sorter = new DefaultItemSorter())
     {
     }
@@ -56,11 +62,22 @@ class ItemList implements Countable, IteratorAggregate
         $list->list = array_reverse($items); // internal sort is largest at the end
         $list->isSorted = $preSorted;
 
+        foreach ($items as $item) {
+            if ($item instanceof LinkedItem) {
+                $group = $item->getLinkedItemGroup();
+                $list->linkedGroupCounts[$group] = ($list->linkedGroupCounts[$group] ?? 0) + 1;
+            }
+        }
+
         return $list;
     }
 
     public function insert(Item $item, int $qty = 1): void
     {
+        if ($item instanceof LinkedItem && $item->getLinkedItemGroup() === '') {
+            throw new InvalidArgumentException("Item '{$item->getDescription()}' has an empty linked item group, which is not allowed");
+        }
+
         for ($i = 0; $i < $qty; ++$i) {
             $this->list[] = $item;
         }
@@ -72,6 +89,11 @@ class ItemList implements Countable, IteratorAggregate
 
         if (isset($this->hasNoRotationItems)) { // normally lazy evaluated, override if that's already been done
             $this->hasNoRotationItems = $this->hasNoRotationItems || $item->getAllowedRotation() === Rotation::Never;
+        }
+
+        if ($item instanceof LinkedItem) {
+            $group = $item->getLinkedItemGroup();
+            $this->linkedGroupCounts[$group] = ($this->linkedGroupCounts[$group] ?? 0) + $qty;
         }
     }
 
@@ -90,6 +112,12 @@ class ItemList implements Countable, IteratorAggregate
         do {
             if (current($this->list) === $item) {
                 unset($this->list[key($this->list)]);
+                if ($item instanceof LinkedItem) {
+                    $group = $item->getLinkedItemGroup();
+                    if (--$this->linkedGroupCounts[$group] === 0) {
+                        unset($this->linkedGroupCounts[$group]);
+                    }
+                }
 
                 return;
             }
@@ -103,6 +131,12 @@ class ItemList implements Countable, IteratorAggregate
             do {
                 if (current($this->list) === $packedItem->item) {
                     unset($this->list[key($this->list)]);
+                    if ($packedItem->item instanceof LinkedItem) {
+                        $group = $packedItem->item->getLinkedItemGroup();
+                        if (--$this->linkedGroupCounts[$group] === 0) {
+                            unset($this->linkedGroupCounts[$group]);
+                        }
+                    }
 
                     break;
                 }
@@ -152,6 +186,13 @@ class ItemList implements Countable, IteratorAggregate
         $topNList = new self();
         $topNList->list = array_slice($this->list, -$n, $n);
         $topNList->isSorted = true;
+
+        foreach ($topNList->list as $item) {
+            if ($item instanceof LinkedItem) {
+                $group = $item->getLinkedItemGroup();
+                $topNList->linkedGroupCounts[$group] = ($topNList->linkedGroupCounts[$group] ?? 0) + 1;
+            }
+        }
 
         return $topNList;
     }
@@ -212,5 +253,25 @@ class ItemList implements Countable, IteratorAggregate
         }
 
         return $this->hasNoRotationItems;
+    }
+
+    /**
+     * Does this list contain items that must be packed in the same box as other items.
+     */
+    public function hasLinkedItems(): bool
+    {
+        return count($this->linkedGroupCounts) > 0;
+    }
+
+    /**
+     * Get a map of linked group identifier => count of items in this list belonging to that group.
+     *
+     * @internal
+     *
+     * @return array<string, int>
+     */
+    public function getLinkedGroupCounts(): array
+    {
+        return $this->linkedGroupCounts;
     }
 }

--- a/src/LinkedGroupPackingConstraint.php
+++ b/src/LinkedGroupPackingConstraint.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+use function count;
+
+/**
+ * Enforces the constraint that linked item groups must not be split across boxes.
+ * If a packed box contains only some members of a linked group, those members are
+ * removed and the box is repacked without them so the freed space can be used by
+ * other eligible items.
+ *
+ * The enforcement loop is iterative and accumulates excluded group IDs so that
+ * items drawn in from $items on one pass cannot reintroduce a group that
+ * was already excluded on an earlier pass. The loop terminates because the set of
+ * excluded groups can only grow, and the eligible item list can only shrink.
+ */
+class LinkedGroupPackingConstraint
+{
+    private LoggerInterface $logger;
+
+    private bool $beStrictAboutItemOrdering = false;
+
+    public function __construct()
+    {
+        $this->logger = new NullLogger();
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function beStrictAboutItemOrdering(bool $beStrict): void
+    {
+        $this->beStrictAboutItemOrdering = $beStrict;
+    }
+
+    public function enforceConstraint(PackedBox $candidate, ItemList $items): PackedBox
+    {
+        if (!$items->hasLinkedItems()) {
+            return $candidate;
+        }
+
+        $excludedGroups = [];
+        $current = $candidate;
+
+        // while there are linked groups that are incomplete, repack without that linked group
+        // so that we fill up the remaining space, while eliminating linked group items that do not fully fit in it
+        // when there are no incomplete linked items remaining we can return the packed box.
+        while (true) {
+            $incompleteLinkedGroups = $this->findIncompleteLinkedGroups($current, $items, $excludedGroups);
+
+            if (count($incompleteLinkedGroups) === 0) {
+                return $current;
+            }
+
+            $excludedGroups += $incompleteLinkedGroups;
+
+            $eligibleItems = $this->buildEligibleItems($items, $excludedGroups);
+
+            $current = $this->repackBox($candidate, $eligibleItems);
+        }
+    }
+
+    /**
+     * Returns the set of linked group IDs that are not all included in $candidate
+     * and are not yet in $alreadyExcluded.
+     *
+     * @param array<string, true> $alreadyExcluded
+     *
+     * @return array<string, true>
+     */
+    private function findIncompleteLinkedGroups(PackedBox $candidate, ItemList $items, array $alreadyExcluded): array
+    {
+        $linkedGroupCounts = $items->getLinkedGroupCounts();
+        $IncompleteLinkedGroups = [];
+
+        foreach ($candidate->items->getLinkedGroupCounts() as $groupId => $packedCount) {
+            if (!isset($alreadyExcluded[$groupId]) && $packedCount < ($linkedGroupCounts[$groupId] ?? 0)) {
+                $IncompleteLinkedGroups[$groupId] = true;
+            }
+        }
+
+        return $IncompleteLinkedGroups;
+    }
+
+    /**
+     * Builds a list of items eligible for repacking: $remainingItems with all members of
+     * $excludedGroups removed.
+     *
+     * @param array<string, true> $excludedGroups
+     */
+    private function buildEligibleItems(ItemList $items, array $excludedGroups): ItemList
+    {
+        $eligible = new ItemList();
+        foreach ($items as $item) {
+            if ($item instanceof LinkedItem && isset($excludedGroups[$item->getLinkedItemGroup()])) {
+                continue;
+            }
+            $eligible->insert($item);
+        }
+
+        return $eligible;
+    }
+
+    /**
+     * Repacks $candidate->box using only $eligibleItems.
+     */
+    private function repackBox(PackedBox $candidate, ItemList $eligibleItems): PackedBox
+    {
+        if ($eligibleItems->count() === 0) {
+            return new PackedBox($candidate->box, new PackedItemList());
+        }
+
+        $volumePacker = new VolumePacker($candidate->box, $eligibleItems);
+        $volumePacker->setLogger($this->logger);
+        $volumePacker->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
+
+        return $volumePacker->pack();
+    }
+}

--- a/src/LinkedItem.php
+++ b/src/LinkedItem.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker;
+
+/**
+ * An item to be packed where all items sharing the same group identifier must end up in the same box.
+ * Only implement this interface if you actually need this additional functionality as it will slow down
+ * the packing algorithm.
+ */
+interface LinkedItem extends Item
+{
+    /**
+     * Returns the group identifier for this item. All items returning the same non-empty identifier
+     * will be packed into the same box. An empty string is invalid and will cause an exception.
+     */
+    public function getLinkedItemGroup(): string;
+}

--- a/src/LinkedItemGroupEnforcer.php
+++ b/src/LinkedItemGroupEnforcer.php
@@ -25,7 +25,7 @@ use function count;
  * was already excluded on an earlier pass. The loop terminates because the set of
  * excluded groups can only grow, and the eligible item list can only shrink.
  */
-class LinkedGroupPackingConstraint
+class LinkedItemGroupEnforcer
 {
     private LoggerInterface $logger;
 
@@ -84,15 +84,15 @@ class LinkedGroupPackingConstraint
     private function findIncompleteLinkedGroups(PackedBox $candidate, ItemList $items, array $alreadyExcluded): array
     {
         $linkedGroupCounts = $items->getLinkedGroupCounts();
-        $IncompleteLinkedGroups = [];
+        $incompleteLinkedGroups = [];
 
         foreach ($candidate->items->getLinkedGroupCounts() as $groupId => $packedCount) {
             if (!isset($alreadyExcluded[$groupId]) && $packedCount < ($linkedGroupCounts[$groupId] ?? 0)) {
-                $IncompleteLinkedGroups[$groupId] = true;
+                $incompleteLinkedGroups[$groupId] = true;
             }
         }
 
-        return $IncompleteLinkedGroups;
+        return $incompleteLinkedGroups;
     }
 
     /**

--- a/src/PackedItemList.php
+++ b/src/PackedItemList.php
@@ -34,11 +34,20 @@ class PackedItemList implements Countable, IteratorAggregate
 
     private bool $isSorted = false;
 
+    /**
+     * @var array<string, int>
+     */
+    private array $linkedGroupCounts = [];
+
     public function insert(PackedItem $item): void
     {
         $this->list[] = $item;
         $this->weight += $item->item->getWeight();
         $this->volume += $item->width * $item->length * $item->depth;
+        if ($item->item instanceof LinkedItem) {
+            $group = $item->item->getLinkedItemGroup();
+            $this->linkedGroupCounts[$group] = ($this->linkedGroupCounts[$group] ?? 0) + 1;
+        }
     }
 
     /**
@@ -88,6 +97,18 @@ class PackedItemList implements Countable, IteratorAggregate
     public function getWeight(): int
     {
         return $this->weight;
+    }
+
+    /**
+     * Get a map of linked group identifier => count of items in this list belonging to that group.
+     *
+     * @internal
+     *
+     * @return array<string, int>
+     */
+    public function getLinkedGroupCounts(): array
+    {
+        return $this->linkedGroupCounts;
     }
 
     private function compare(PackedItem $itemA, PackedItem $itemB): int

--- a/src/Packer.php
+++ b/src/Packer.php
@@ -204,6 +204,10 @@ class Packer implements LoggerAwareInterface
                 $volumePacker->setLogger($this->logger);
                 $volumePacker->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
                 $packedBox = $volumePacker->pack();
+                $linkedGroupConstraint = new LinkedGroupPackingConstraint();
+                $linkedGroupConstraint->setLogger($this->logger);
+                $linkedGroupConstraint->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
+                $packedBox = $linkedGroupConstraint->enforceConstraint($packedBox, $this->items);
                 if ($packedBox->items->count()) {
                     $packedBoxesIteration[] = $packedBox;
 
@@ -270,6 +274,9 @@ class Packer implements LoggerAwareInterface
                     $volumePacker = new VolumePacker($box, $wipPermutation['itemsLeft']);
                     $volumePacker->setLogger($this->logger);
                     $packedBox = $volumePacker->pack();
+                    $linkedGroupConstraint = new LinkedGroupPackingConstraint();
+                    $linkedGroupConstraint->setLogger($this->logger);
+                    $packedBox = $linkedGroupConstraint->enforceConstraint($packedBox, $wipPermutation['itemsLeft']);
                     if ($packedBox->items->count()) {
                         $additionalPermutationsForThisPermutation[] = $packedBox;
                     }

--- a/src/Packer.php
+++ b/src/Packer.php
@@ -204,10 +204,10 @@ class Packer implements LoggerAwareInterface
                 $volumePacker->setLogger($this->logger);
                 $volumePacker->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
                 $packedBox = $volumePacker->pack();
-                $linkedGroupConstraint = new LinkedGroupPackingConstraint();
-                $linkedGroupConstraint->setLogger($this->logger);
-                $linkedGroupConstraint->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
-                $packedBox = $linkedGroupConstraint->enforceConstraint($packedBox, $this->items);
+                $linkedItemGroupEnforcer = new LinkedItemGroupEnforcer();
+                $linkedItemGroupEnforcer->setLogger($this->logger);
+                $linkedItemGroupEnforcer->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
+                $packedBox = $linkedItemGroupEnforcer->enforceConstraint($packedBox, $this->items);
                 if ($packedBox->items->count()) {
                     $packedBoxesIteration[] = $packedBox;
 
@@ -273,9 +273,11 @@ class Packer implements LoggerAwareInterface
                 if ($remainingBoxQuantities[$box] > 0) {
                     $volumePacker = new VolumePacker($box, $wipPermutation['itemsLeft']);
                     $volumePacker->setLogger($this->logger);
+                    $volumePacker->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
                     $packedBox = $volumePacker->pack();
-                    $linkedGroupConstraint = new LinkedGroupPackingConstraint();
+                    $linkedGroupConstraint = new LinkedItemGroupEnforcer();
                     $linkedGroupConstraint->setLogger($this->logger);
+                    $linkedGroupConstraint->beStrictAboutItemOrdering($this->beStrictAboutItemOrdering);
                     $packedBox = $linkedGroupConstraint->enforceConstraint($packedBox, $wipPermutation['itemsLeft']);
                     if ($packedBox->items->count()) {
                         $additionalPermutationsForThisPermutation[] = $packedBox;

--- a/src/WeightRedistributor.php
+++ b/src/WeightRedistributor.php
@@ -108,6 +108,11 @@ class WeightRedistributor implements LoggerAwareInterface
 
         foreach ($overWeightBoxItems as $key => $overWeightItem) {
             $this->timeoutChecker?->throwOnTimeout();
+
+            if ($overWeightItem instanceof LinkedItem) {
+                continue; // cannot move individual linked group members; weight balance is secondary to group integrity
+            }
+
             if (!self::wouldRepackActuallyHelp($overWeightBoxItems, $overWeightItem, $underWeightBoxItems, $targetWeight)) {
                 continue; // moving this item would harm more than help
             }

--- a/tests/LinkedGroupPackingConstraintTest.php
+++ b/tests/LinkedGroupPackingConstraintTest.php
@@ -1,0 +1,388 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker;
+
+use DVDoug\BoxPacker\Test\LinkedTestItem;
+use DVDoug\BoxPacker\Test\TestBox;
+use DVDoug\BoxPacker\Test\TestItem;
+use PHPUnit\Framework\TestCase;
+
+use function in_array;
+
+class LinkedGroupPackingConstraintTest extends TestCase
+{
+    /**
+     * When $remainingItems contains no LinkedItem instances, hasLinkedItems() returns false
+     * and the candidate must be returned unchanged via the early-return path (no loop entered).
+     */
+    public function testEnforceConstraintNoLinkedItemsReturnsCandidateUnchanged(): void
+    {
+        $box = new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000);
+
+        $items = new ItemList();
+        $items->insert(new TestItem('Item 1', 30, 10, 10, 10, Rotation::KeepFlat));
+        $items->insert(new TestItem('Item 2', 30, 10, 10, 10, Rotation::KeepFlat));
+
+        $volumePacker = new VolumePacker($box, $items);
+        $candidate = $volumePacker->pack();
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $items);
+
+        self::assertSame(
+            $candidate,
+            $result,
+            'Candidate must be returned unchanged when $remainingItems has no linked items'
+        );
+    }
+
+    /**
+     * When all members of every linked group are present in the packed box (no partial groups),
+     * findNewPartialGroups() returns empty on the first iteration and the candidate must be
+     * returned unchanged without any repack.
+     */
+    public function testEnforceConstraintAllGroupsCompleteReturnsCandidateUnchanged(): void
+    {
+        $box = new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000);
+
+        $item1 = new LinkedTestItem('Item 1', 30, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $item2 = new LinkedTestItem('Item 2', 30, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+
+        $items = new ItemList();
+        $items->insert($item1);
+        $items->insert($item2);
+
+        $volumePacker = new VolumePacker($box, $items);
+        $candidate = $volumePacker->pack();
+
+        $remainingItems = new ItemList();
+        $remainingItems->insert($item1);
+        $remainingItems->insert($item2);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        self::assertSame($candidate, $result, 'Candidate must be returned unchanged when no partial groups exist');
+    }
+
+    /**
+     * When the candidate contains no packed linked items but $remainingItems does contain
+     * linked items, getLinkedGroupCounts() on the packed list returns empty and
+     * findNewPartialGroups() finds nothing to exclude — the candidate is returned unchanged.
+     */
+    public function testEnforceConstraintCandidateHasNoLinkedItemsPacked(): void
+    {
+        $box = new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000);
+
+        $normal = new TestItem('Normal', 10, 10, 10, 10, Rotation::KeepFlat);
+        $linked1 = new LinkedTestItem('Linked 1', 30, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $linked2 = new LinkedTestItem('Linked 2', 30, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+
+        // Candidate contains only the non-linked item.
+        $packedItems = new ItemList();
+        $packedItems->insert($normal);
+        $volumePacker = new VolumePacker($box, $packedItems);
+        $candidate = $volumePacker->pack();
+
+        // $remainingItems includes linked items, but the candidate never packed any of them.
+        $remainingItems = new ItemList();
+        $remainingItems->insert($normal);
+        $remainingItems->insert($linked1);
+        $remainingItems->insert($linked2);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        self::assertSame($candidate, $result, 'Candidate must be unchanged when no linked items were packed in it');
+    }
+
+    /**
+     * When every item in the candidate belongs to a partial linked group and there are no
+     * non-linked items, after exclusion the restricted list is empty and the result must be
+     * a PackedBox for the same box containing zero items.
+     */
+    public function testEnforceConstraintAllItemsArePartialGroupProducesEmptyBox(): void
+    {
+        $box = new TestBox('Box', 60, 10, 10, 0, 60, 10, 10, 10000);
+
+        // Only A1 fits; A1 + A2 = 100mm > 60mm box.
+        $groupA1 = new LinkedTestItem('Group A - 1', 50, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupA2 = new LinkedTestItem('Group A - 2', 50, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+
+        $packedItems = new ItemList();
+        $packedItems->insert($groupA1);
+        $volumePacker = new VolumePacker($box, $packedItems);
+        $candidate = $volumePacker->pack();
+
+        $remainingItems = new ItemList();
+        $remainingItems->insert($groupA1);
+        $remainingItems->insert($groupA2);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        self::assertSame($box, $result->box, 'Box reference must be preserved');
+        self::assertCount(0, $result->items, 'Result must be empty when all candidate items belong to a partial group');
+    }
+
+    /**
+     * When two different linked groups are both partial in the original candidate,
+     * both must be identified and excluded in a single buildRestrictedItems pass,
+     * leaving only non-linked items in the repacked result.
+     */
+    public function testEnforceConstraintTwoSimultaneousPartialGroupsBothRemoved(): void
+    {
+        // Box: 100mm. Candidate: A1(50) + B1(15) + regular(10) = 75mm.
+        // A2(50) and B2(15) exist in $remainingItems but were not packed in the candidate.
+        // Both group-A and group-B are partial simultaneously, so both must be removed
+        // in the same repack pass, leaving only the regular item.
+        $box = new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000);
+
+        $groupA1 = new LinkedTestItem('Group A - 1', 50, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupA2 = new LinkedTestItem('Group A - 2', 50, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupB1 = new LinkedTestItem('Group B - 1', 15, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+        $groupB2 = new LinkedTestItem('Group B - 2', 15, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+        $regular = new TestItem('Regular', 10, 10, 10, 10, Rotation::KeepFlat);
+
+        $packedItems = new ItemList();
+        $packedItems->insert($groupA1);
+        $packedItems->insert($groupB1);
+        $packedItems->insert($regular);
+        $volumePacker = new VolumePacker($box, $packedItems);
+        $candidate = $volumePacker->pack();
+
+        $remainingItems = new ItemList();
+        $remainingItems->insert($groupA1);
+        $remainingItems->insert($groupA2);
+        $remainingItems->insert($groupB1);
+        $remainingItems->insert($groupB2);
+        $remainingItems->insert($regular);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        $packedItemObjects = [];
+        foreach ($result->items as $packedItem) {
+            $packedItemObjects[] = $packedItem->item;
+        }
+
+        self::assertNotContains($groupA1, $packedItemObjects, 'Partial group-A member must be excluded');
+        self::assertNotContains($groupB1, $packedItemObjects, 'Partial group-B member must be excluded');
+        self::assertContains($regular, $packedItemObjects, 'Non-linked item must be retained');
+    }
+
+    /**
+     * Smoke test: enforceConstraint() orchestrates removal and repacking correctly.
+     * A partial linked group member must be absent from the result while a non-linked
+     * item must remain.
+     */
+    public function testEnforceConstraintPartialGroupRemovedAndBoxRepacked(): void
+    {
+        $box = new TestBox('Box', 60, 10, 10, 0, 60, 10, 10, 10000);
+
+        $item1 = new LinkedTestItem('Linked 1', 50, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $item2 = new LinkedTestItem('Linked 2', 50, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $standalone = new TestItem('Standalone', 30, 10, 10, 10, Rotation::KeepFlat);
+
+        $packedItems = new ItemList();
+        $packedItems->insert($item1);
+        $packedItems->insert($standalone);
+
+        $volumePacker = new VolumePacker($box, $packedItems);
+        $candidate = $volumePacker->pack();
+
+        $remainingItems = new ItemList();
+        $remainingItems->insert($item1);
+        $remainingItems->insert($item2);
+        $remainingItems->insert($standalone);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        $packedItemObjects = [];
+        foreach ($result->items as $packedItem) {
+            $packedItemObjects[] = $packedItem->item;
+        }
+
+        self::assertNotContains($item1, $packedItemObjects, 'Partial linked group member must be removed');
+        self::assertContains($standalone, $packedItemObjects, 'Non-linked item must remain packed');
+    }
+
+    /**
+     * When group-A is partial and group-B is complete (both members in the candidate),
+     * enforceConstraint() must produce a repacked box that contains both group-B items.
+     */
+    public function testEnforceConstraintCompleteGroupPreservedAlongsidePartialGroup(): void
+    {
+        // Box fits groupA1(60) + groupB1(15) + groupB2(15) = 90 ≤ 100.
+        // group-A is partial (A2 not in candidate); group-B is complete.
+        $box = new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000);
+
+        $groupA1 = new LinkedTestItem('Group A - 1', 60, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupA2 = new LinkedTestItem('Group A - 2', 60, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupB1 = new LinkedTestItem('Group B - 1', 15, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+        $groupB2 = new LinkedTestItem('Group B - 2', 15, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+
+        $packedItems = new ItemList();
+        $packedItems->insert($groupA1);
+        $packedItems->insert($groupB1);
+        $packedItems->insert($groupB2);
+
+        $volumePacker = new VolumePacker($box, $packedItems);
+        $candidate = $volumePacker->pack();
+
+        $remainingItems = new ItemList();
+        $remainingItems->insert($groupA1);
+        $remainingItems->insert($groupA2);
+        $remainingItems->insert($groupB1);
+        $remainingItems->insert($groupB2);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        $packedItemObjects = [];
+        foreach ($result->items as $packedItem) {
+            $packedItemObjects[] = $packedItem->item;
+        }
+
+        self::assertNotContains($groupA1, $packedItemObjects, 'Partial group-A member must be excluded');
+        self::assertContains($groupB1, $packedItemObjects, 'Complete group-B member must be in result');
+        self::assertContains($groupB2, $packedItemObjects, 'Complete group-B member must be in result');
+    }
+
+    /**
+     * When 3 distinct linked products each have their own group and A and B cannot
+     * all fit in the box (only partial members of those groups pack), but C's two
+     * members both fit, the constraint must remove groups A and B and return a box
+     * containing only the complete group C.
+     *
+     * Box: 100mm.
+     * Candidate (built from A1+C1+C2): A1(60) + C1(20) + C2(20) = 100mm.
+     *   group-A is partial (A2 absent) → removed on first pass.
+     * First repack [B1,B2,C1,C2]: B1(60)+C1(20)+C2(20)=100mm; B2 doesn't fit.
+     *   group-B is partial → removed on second pass.
+     * Second repack [C1,C2]: 40mm, both fit and group-C is complete → returned.
+     */
+    public function testThreeDistinctGroupsOnlyFittingGroupIsPacked(): void
+    {
+        $box = new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000);
+
+        $groupA1 = new LinkedTestItem('Group A - 1', 60, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupA2 = new LinkedTestItem('Group A - 2', 60, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupB1 = new LinkedTestItem('Group B - 1', 60, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+        $groupB2 = new LinkedTestItem('Group B - 2', 60, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+        $groupC1 = new LinkedTestItem('Group C - 1', 20, 10, 10, 10, Rotation::KeepFlat, 'group-C');
+        $groupC2 = new LinkedTestItem('Group C - 2', 20, 10, 10, 10, Rotation::KeepFlat, 'group-C');
+
+        // Candidate: A1(60) + C1(20) + C2(20) = 100mm — group-A partial, group-C complete.
+        $packedItems = new ItemList();
+        $packedItems->insert($groupA1);
+        $packedItems->insert($groupC1);
+        $packedItems->insert($groupC2);
+
+        $volumePacker = new VolumePacker($box, $packedItems);
+        $candidate = $volumePacker->pack();
+
+        $remainingItems = new ItemList();
+        $remainingItems->insert($groupA1);
+        $remainingItems->insert($groupA2);
+        $remainingItems->insert($groupB1);
+        $remainingItems->insert($groupB2);
+        $remainingItems->insert($groupC1);
+        $remainingItems->insert($groupC2);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        $packedItemObjects = [];
+        foreach ($result->items as $packedItem) {
+            $packedItemObjects[] = $packedItem->item;
+        }
+
+        self::assertNotContains($groupA1, $packedItemObjects, 'Partial group-A must not be packed');
+        self::assertNotContains($groupA2, $packedItemObjects, 'Partial group-A must not be packed');
+        self::assertNotContains($groupB1, $packedItemObjects, 'Partial group-B must not be packed');
+        self::assertNotContains($groupB2, $packedItemObjects, 'Partial group-B must not be packed');
+        self::assertContains($groupC1, $packedItemObjects, 'Complete group-C member must be packed');
+        self::assertContains($groupC2, $packedItemObjects, 'Complete group-C member must be packed');
+    }
+
+    /**
+     * candidate, the recursive enforcement in enforceConstraint() must prevent those
+     * items from forming a new partial group in the repacked result.
+     *
+     * Scenario:
+     *   - Box: 40mm wide.
+     *   - Original candidate: [A1(30mm, group-A partial), regular(10mm)].
+     *   - $remainingItems also has C1(20mm, group-C) and C2(25mm, group-C).
+     *   - First repack uses restrictedItems = [regular(10), C1(20), C2(25)].
+     *     VolumePacker sorts largest-first: C2(25) + regular(10) = 35 fits; C1(20) → 55 > 40 — no.
+     *     Without the recursive call, the result [C2, regular] has group-C partial (C2 packed, C1 not).
+     *   - The recursive call detects group-C partial, rebuilds restrictedItems = [regular],
+     *     and produces a clean result containing only the regular item.
+     */
+    public function testEnforceConstraintDoesNotCreateNewPartialGroupFromRemainingItems(): void
+    {
+        // Box is 40mm wide.
+        // A1 = 30mm (group-A, partial — A2 also in remaining but not in candidate).
+        // regular = 10mm (fits alongside A1 in the original candidate; small enough to
+        //   fit alongside C2 in the first repack, triggering the partial-group scenario).
+        // C2 = 25mm, C1 = 20mm (group-C — C2 fits with regular(10) = 35 ≤ 40,
+        //   but C2(25) + C1(20) = 45 > 40 so C1 cannot join C2 in the repack).
+        $box = new TestBox('Box', 40, 10, 10, 0, 40, 10, 10, 10000);
+
+        $groupA1 = new LinkedTestItem('Group A - 1', 30, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $groupA2 = new LinkedTestItem('Group A - 2', 30, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $regular = new TestItem('Regular', 10, 10, 10, 10, Rotation::KeepFlat);
+        $groupC1 = new LinkedTestItem('Group C - 1', 20, 10, 10, 10, Rotation::KeepFlat, 'group-C');
+        $groupC2 = new LinkedTestItem('Group C - 2', 25, 10, 10, 10, Rotation::KeepFlat, 'group-C');
+
+        // Original candidate: A1(30) + regular(10) = 40mm — exactly fills the box.
+        $packedItems = new ItemList();
+        $packedItems->insert($groupA1);
+        $packedItems->insert($regular);
+
+        $volumePacker = new VolumePacker($box, $packedItems);
+        $candidate = $volumePacker->pack();
+
+        // $remainingItems also has A2, C1, C2.  When the first repack removes A1/A2
+        // (group-A partial), it will try to fit [regular(10), C1(20), C2(25)].
+        // VolumePacker picks C2(25) first; C2+regular=35 fits; C1(20) would push it to 55 — no.
+        // Result of first repack: [C2, regular] — group-C is now partial (C2 in, C1 out).
+        // The recursive enforceConstraint call must catch this and strip group-C members,
+        // yielding a final result that contains only the regular item.
+        $remainingItems = new ItemList();
+        $remainingItems->insert($groupA1);
+        $remainingItems->insert($groupA2);
+        $remainingItems->insert($regular);
+        $remainingItems->insert($groupC1);
+        $remainingItems->insert($groupC2);
+
+        $constraint = new LinkedGroupPackingConstraint();
+        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+
+        $packedItemObjects = [];
+        foreach ($result->items as $packedItem) {
+            $packedItemObjects[] = $packedItem->item;
+        }
+
+        // group-A members must not be present (partial group)
+        self::assertNotContains($groupA1, $packedItemObjects, 'Partial group-A must not be in result');
+
+        // group-C must not be split: either both C1 and C2 are present, or neither is
+        $c1Present = in_array($groupC1, $packedItemObjects, true);
+        $c2Present = in_array($groupC2, $packedItemObjects, true);
+        self::assertSame($c1Present, $c2Present, 'group-C must not be split: both or neither must be present');
+
+        // The regular item must be packed — it is the only valid item once both partial
+        // groups (A and C) are stripped, and it was proven to fit in the original candidate.
+        self::assertContains($regular, $packedItemObjects, 'Regular item from original candidate must remain packed');
+    }
+}

--- a/tests/LinkedGroupPackingConstraintTest.php
+++ b/tests/LinkedGroupPackingConstraintTest.php
@@ -33,8 +33,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $volumePacker = new VolumePacker($box, $items);
         $candidate = $volumePacker->pack();
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $items);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $items);
 
         self::assertSame(
             $candidate,
@@ -66,8 +66,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($item1);
         $remainingItems->insert($item2);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         self::assertSame($candidate, $result, 'Candidate must be returned unchanged when no partial groups exist');
     }
@@ -97,8 +97,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($linked1);
         $remainingItems->insert($linked2);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         self::assertSame($candidate, $result, 'Candidate must be unchanged when no linked items were packed in it');
     }
@@ -125,8 +125,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($groupA1);
         $remainingItems->insert($groupA2);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         self::assertSame($box, $result->box, 'Box reference must be preserved');
         self::assertCount(0, $result->items, 'Result must be empty when all candidate items belong to a partial group');
@@ -165,8 +165,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($groupB2);
         $remainingItems->insert($regular);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         $packedItemObjects = [];
         foreach ($result->items as $packedItem) {
@@ -203,8 +203,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($item2);
         $remainingItems->insert($standalone);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         $packedItemObjects = [];
         foreach ($result->items as $packedItem) {
@@ -244,8 +244,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($groupB1);
         $remainingItems->insert($groupB2);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         $packedItemObjects = [];
         foreach ($result->items as $packedItem) {
@@ -298,8 +298,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($groupC1);
         $remainingItems->insert($groupC2);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         $packedItemObjects = [];
         foreach ($result->items as $packedItem) {
@@ -365,8 +365,8 @@ class LinkedGroupPackingConstraintTest extends TestCase
         $remainingItems->insert($groupC1);
         $remainingItems->insert($groupC2);
 
-        $constraint = new LinkedGroupPackingConstraint();
-        $result = $constraint->enforceConstraint($candidate, $remainingItems);
+        $enforcer = new LinkedItemGroupEnforcer();
+        $result = $enforcer->enforceConstraint($candidate, $remainingItems);
 
         $packedItemObjects = [];
         foreach ($result->items as $packedItem) {

--- a/tests/LinkedItemTest.php
+++ b/tests/LinkedItemTest.php
@@ -1,0 +1,353 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker;
+
+use DVDoug\BoxPacker\Exception\NoBoxesAvailableException;
+use DVDoug\BoxPacker\Test\LinkedTestItem;
+use DVDoug\BoxPacker\Test\TestBox;
+use DVDoug\BoxPacker\Test\TestItem;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+use function iterator_to_array;
+
+class LinkedItemTest extends TestCase
+{
+    /**
+     * Two items in the same group that both fit comfortably: both end up in the same box.
+     */
+    public function testLinkedItemsPackedInSameBox(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Large box', 100, 100, 100, 0, 100, 100, 100, 10000));
+
+        $item1 = new LinkedTestItem('Item 1', 10, 10, 10, 100, Rotation::BestFit, 'group-A');
+        $item2 = new LinkedTestItem('Item 2', 10, 10, 10, 100, Rotation::BestFit, 'group-A');
+        $packer->addItem($item1);
+        $packer->addItem($item2);
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        self::assertCount(1, $packedBoxes);
+        self::assertCount(2, $packedBoxes[0]->items);
+    }
+
+    /**
+     * Two linked items that would each individually fit into the small box, but not together.
+     * They must be moved to the large box.
+     */
+    public function testLinkedItemsMovedToLargerBoxWhenRequiredToFitTogether(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Small box', 60, 10, 10, 0, 60, 10, 10, 10000));
+        $packer->addBox(new TestBox('Large box', 100, 10, 10, 0, 100, 10, 10, 10000));
+
+        // Each item is 50 wide — fits alone in small box (60), but not both together (needs 100)
+        $item1 = new LinkedTestItem('Item 1', 50, 10, 10, 100, Rotation::KeepFlat, 'group-A');
+        $item2 = new LinkedTestItem('Item 2', 50, 10, 10, 100, Rotation::KeepFlat, 'group-A');
+        $packer->addItem($item1);
+        $packer->addItem($item2);
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        self::assertCount(1, $packedBoxes);
+        self::assertEquals('Large box', $packedBoxes[0]->box->getReference());
+        self::assertCount(2, $packedBoxes[0]->items);
+    }
+
+    /**
+     * Three linked items: packer puts them all in one box rather than splitting them.
+     */
+    public function testThreeLinkedItemsPackedTogether(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Small box', 10, 10, 10, 0, 10, 10, 10, 10000));
+        $packer->addBox(new TestBox('Large box', 30, 10, 10, 0, 30, 10, 10, 10000));
+
+        $item1 = new LinkedTestItem('Item 1', 10, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $item2 = new LinkedTestItem('Item 2', 10, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $item3 = new LinkedTestItem('Item 3', 10, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $packer->addItem($item1);
+        $packer->addItem($item2);
+        $packer->addItem($item3);
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        self::assertCount(1, $packedBoxes);
+        self::assertCount(3, $packedBoxes[0]->items);
+    }
+
+    /**
+     * When addItem is called with qty > 1, all instances are part of the same linked group.
+     */
+    public function testQuantityLinkedItemsAreAllLinked(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Small box', 10, 10, 10, 0, 10, 10, 10, 10000));
+        $packer->addBox(new TestBox('Large box', 30, 10, 10, 0, 30, 10, 10, 10000));
+
+        $item = new LinkedTestItem('Item', 10, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $packer->addItem($item, 3); // same object, qty 3
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        // All 3 instances share group-A, so they must all be in one box
+        self::assertCount(1, $packedBoxes);
+        self::assertCount(3, $packedBoxes[0]->items);
+    }
+
+    /**
+     * Linked items from different groups can be split across boxes.
+     */
+    public function testDifferentGroupsCanBeSplitAcrossBoxes(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Small box', 50, 10, 10, 0, 50, 10, 10, 10000));
+
+        // group-A: 2 items × 30mm wide = 60mm → won't both fit in 50mm
+        $item1 = new LinkedTestItem('Item 1', 30, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $item2 = new LinkedTestItem('Item 2', 20, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        // group-B: 2 items × 20mm wide = 40mm → both fit in 50mm
+        $item3 = new LinkedTestItem('Item 3', 20, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+        $item4 = new LinkedTestItem('Item 4', 20, 10, 10, 10, Rotation::KeepFlat, 'group-B');
+
+        $packer->addBox(new TestBox('Large box', 60, 10, 10, 0, 60, 10, 10, 10000));
+        $packer->addItem($item1);
+        $packer->addItem($item2);
+        $packer->addItem($item3);
+        $packer->addItem($item4);
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        // All items fit, two groups must each be intact
+        $groupABoxes = array_filter($packedBoxes, static function (PackedBox $box): bool {
+            foreach ($box->items as $packedItem) {
+                if ($packedItem->item instanceof LinkedTestItem && $packedItem->item->getLinkedItemGroup() === 'group-A') {
+                    return true;
+                }
+            }
+            return false;
+        });
+        $groupBBoxes = array_filter($packedBoxes, static function (PackedBox $box): bool {
+            foreach ($box->items as $packedItem) {
+                if ($packedItem->item instanceof LinkedTestItem && $packedItem->item->getLinkedItemGroup() === 'group-B') {
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        // Each group should only appear in exactly one box
+        self::assertCount(1, $groupABoxes);
+        self::assertCount(1, $groupBBoxes);
+
+        foreach ($groupABoxes as $box) {
+            $count = 0;
+            foreach ($box->items as $packedItem) {
+                if ($packedItem->item instanceof LinkedTestItem && $packedItem->item->getLinkedItemGroup() === 'group-A') {
+                    ++$count;
+                }
+            }
+            self::assertSame(2, $count, 'Both group-A items must be in the same box');
+        }
+        foreach ($groupBBoxes as $box) {
+            $count = 0;
+            foreach ($box->items as $packedItem) {
+                if ($packedItem->item instanceof LinkedTestItem && $packedItem->item->getLinkedItemGroup() === 'group-B') {
+                    ++$count;
+                }
+            }
+            self::assertSame(2, $count, 'Both group-B items must be in the same box');
+        }
+    }
+
+    /**
+     * Empty group IDs are not allowed.
+     */
+    public function testEmptyGroupIdThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Box', 100, 100, 100, 0, 100, 100, 100, 10000));
+        $packer->addItem(new LinkedTestItem('Item', 10, 10, 10, 10, Rotation::BestFit, ''));
+    }
+
+    /**
+     * When throwOnUnpackableItem(false), unpackable linked groups are skipped but other items still pack.
+     */
+    public function testUnpackableLinkedGroupSkippedWhenNotThrowing(): void
+    {
+        $packer = new Packer();
+        $packer->throwOnUnpackableItem(false);
+        $packer->addBox(new TestBox('Tiny box', 5, 5, 5, 0, 5, 5, 5, 10000));
+
+        // This group cannot fit together (each item is 5×5×5, together they need 10 wide)
+        $item1 = new LinkedTestItem('Linked 1', 5, 5, 5, 10, Rotation::KeepFlat, 'group-A');
+        $item2 = new LinkedTestItem('Linked 2', 5, 5, 5, 10, Rotation::KeepFlat, 'group-A');
+        // This standalone item fits fine on its own
+        $standalone = new TestItem('Standalone', 5, 5, 5, 10, Rotation::KeepFlat);
+
+        $packer->addItem($item1);
+        $packer->addItem($item2);
+        $packer->addItem($standalone);
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        // Standalone item should still be packed
+        $allPackedItems = [];
+        foreach ($packedBoxes as $packedBox) {
+            foreach ($packedBox->items as $packedItem) {
+                $allPackedItems[] = $packedItem->item;
+            }
+        }
+        self::assertContains($standalone, $allPackedItems);
+        // Linked items should NOT be packed (group cannot fit together)
+        self::assertNotContains($item1, $allPackedItems);
+        self::assertNotContains($item2, $allPackedItems);
+    }
+
+    /**
+     * Unpackable linked group throws NoBoxesAvailableException when throwOnUnpackableItem(true).
+     */
+    public function testUnpackableLinkedGroupThrowsWhenConfigured(): void
+    {
+        $this->expectException(NoBoxesAvailableException::class);
+
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Tiny box', 5, 5, 5, 0, 5, 5, 5, 10000));
+
+        // Two items in a group, each 5×5×5; they cannot fit together in the 5×5×5 box
+        $packer->addItem(new LinkedTestItem('Linked 1', 5, 5, 5, 10, Rotation::KeepFlat, 'group-A'));
+        $packer->addItem(new LinkedTestItem('Linked 2', 5, 5, 5, 10, Rotation::KeepFlat, 'group-A'));
+
+        $packer->pack();
+    }
+
+    /**
+     * packAllPermutations() must never return a permutation that splits a linked group.
+     */
+    public function testPermutationsPreserveLinkedGroups(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Small box', 50, 10, 10, 0, 50, 10, 10, 10000));
+        $packer->addBox(new TestBox('Large box', 100, 10, 10, 0, 100, 10, 10, 10000));
+
+        // Group items that need at least 100mm together
+        $item1 = new LinkedTestItem('Item 1', 60, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $item2 = new LinkedTestItem('Item 2', 40, 10, 10, 10, Rotation::KeepFlat, 'group-A');
+        $packer->addItem($item1);
+        $packer->addItem($item2);
+
+        $permutations = $packer->packAllPermutations();
+
+        self::assertNotEmpty($permutations);
+        foreach ($permutations as $permutation) {
+            $groupBoxes = [];
+            foreach ($permutation as $packedBox) {
+                foreach ($packedBox->items as $packedItem) {
+                    if ($packedItem->item instanceof LinkedTestItem) {
+                        $groupId = $packedItem->item->getLinkedItemGroup();
+                        // Assign the box index to this group; fail if two different boxes claim the same group
+                        $boxRef = spl_object_id($packedBox);
+                        if (isset($groupBoxes[$groupId]) && $groupBoxes[$groupId] !== $boxRef) {
+                            self::fail("Permutation splits linked group '{$groupId}' across multiple boxes");
+                        }
+                        $groupBoxes[$groupId] = $boxRef;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Weight redistribution must not split a linked group between boxes.
+     */
+    public function testWeightRedistributionDoesNotSplitLinkedGroups(): void
+    {
+        $packer = new Packer();
+        // Two identical boxes
+        $packer->addBox(new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000));
+
+        // A linked group of 2 heavy items
+        $linkedHeavy1 = new LinkedTestItem('Heavy 1', 20, 10, 10, 400, Rotation::KeepFlat, 'heavy-group');
+        $linkedHeavy2 = new LinkedTestItem('Heavy 2', 20, 10, 10, 400, Rotation::KeepFlat, 'heavy-group');
+        // Two light standalone items
+        $light1 = new TestItem('Light 1', 20, 10, 10, 50, Rotation::KeepFlat);
+        $light2 = new TestItem('Light 2', 20, 10, 10, 50, Rotation::KeepFlat);
+
+        $packer->addItem($linkedHeavy1);
+        $packer->addItem($linkedHeavy2);
+        $packer->addItem($light1);
+        $packer->addItem($light2);
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        // Find which box contains the heavy-group members
+        $heavy1Box = null;
+        $heavy2Box = null;
+        foreach ($packedBoxes as $packedBox) {
+            foreach ($packedBox->items as $packedItem) {
+                if ($packedItem->item === $linkedHeavy1) {
+                    $heavy1Box = spl_object_id($packedBox);
+                }
+                if ($packedItem->item === $linkedHeavy2) {
+                    $heavy2Box = spl_object_id($packedBox);
+                }
+            }
+        }
+
+        self::assertNotNull($heavy1Box, 'heavy-group item 1 must be packed');
+        self::assertNotNull($heavy2Box, 'heavy-group item 2 must be packed');
+        self::assertSame($heavy1Box, $heavy2Box, 'Weight redistribution must not split the heavy-group');
+    }
+
+    /**
+     * Linked items from different groups interleaved with non-linked items pack correctly.
+     */
+    public function testMixedLinkedAndUnlinkedItems(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new TestBox('Box', 100, 10, 10, 0, 100, 10, 10, 10000));
+
+        $linked1 = new LinkedTestItem('Linked A1', 20, 10, 10, 100, Rotation::KeepFlat, 'group-A');
+        $linked2 = new LinkedTestItem('Linked A2', 20, 10, 10, 100, Rotation::KeepFlat, 'group-A');
+        $normal = new TestItem('Normal', 20, 10, 10, 50, Rotation::KeepFlat);
+
+        $packer->addItem($linked1);
+        $packer->addItem($normal);
+        $packer->addItem($linked2);
+
+        /** @var PackedBox[] $packedBoxes */
+        $packedBoxes = iterator_to_array($packer->pack(), false);
+
+        // Verify both linked items end up in the same box
+        $linked1Box = null;
+        $linked2Box = null;
+        foreach ($packedBoxes as $packedBox) {
+            foreach ($packedBox->items as $packedItem) {
+                if ($packedItem->item === $linked1) {
+                    $linked1Box = spl_object_id($packedBox);
+                }
+                if ($packedItem->item === $linked2) {
+                    $linked2Box = spl_object_id($packedBox);
+                }
+            }
+        }
+        self::assertSame($linked1Box, $linked2Box, 'Linked group-A items must be in the same box');
+    }
+}

--- a/tests/LinkedItemTest.php
+++ b/tests/LinkedItemTest.php
@@ -17,6 +17,8 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 use function iterator_to_array;
+use function array_filter;
+use function spl_object_id;
 
 class LinkedItemTest extends TestCase
 {
@@ -138,6 +140,7 @@ class LinkedItemTest extends TestCase
                     return true;
                 }
             }
+
             return false;
         });
         $groupBBoxes = array_filter($packedBoxes, static function (PackedBox $box): bool {
@@ -146,6 +149,7 @@ class LinkedItemTest extends TestCase
                     return true;
                 }
             }
+
             return false;
         });
 

--- a/tests/Test/LinkedTestItem.php
+++ b/tests/Test/LinkedTestItem.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Box packing (3D bin packing, knapsack problem).
+ *
+ * @author Doug Wright
+ */
+declare(strict_types=1);
+
+namespace DVDoug\BoxPacker\Test;
+
+use DVDoug\BoxPacker\LinkedItem;
+use DVDoug\BoxPacker\Rotation;
+
+class LinkedTestItem extends TestItem implements LinkedItem
+{
+    public function __construct(
+        string $description,
+        int $width,
+        int $length,
+        int $depth,
+        int $weight,
+        Rotation $allowedRotation,
+        private readonly string $linkedItemGroup,
+    ) {
+        parent::__construct($description, $width, $length, $depth, $weight, $allowedRotation);
+    }
+
+    public function getLinkedItemGroup(): string
+    {
+        return $this->linkedItemGroup;
+    }
+}


### PR DESCRIPTION
An implementation for issue #657

- Adds LinkedItem interface: signifies an item that must not be split up
- Adds LinkedGroupPackingConstraint: ensures no linked items get partially packed
- Modifies ItemList and PackedItemList to add support for LinkedItems 
- Adds documentation for this new feature
