### PR TITLE
Fix weight redistributor sometimes dropping items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [4.x - Unreleased] - 2026-xx-xx
-
+### Fixed
+- In some rare cases `WeightRedistributor` would silently drop items
+ 
 ## [4.2.0] - 2026-07-05
 ### Added
 - A mechanism to allow forcing certain items to be packed together [RubenKluft]

--- a/src/WeightRedistributor.php
+++ b/src/WeightRedistributor.php
@@ -117,8 +117,9 @@ class WeightRedistributor implements LoggerAwareInterface
                 continue; // moving this item would harm more than help
             }
 
-            $newLighterBoxes = $this->doVolumeRepack(array_merge($underWeightBoxItems, [$overWeightItem]), $underWeightBox->box);
-            if ($newLighterBoxes->count() !== 1) {
+            $packableItems = array_merge($underWeightBoxItems, [$overWeightItem]);
+            $newLighterBoxes = $this->doVolumeRepack($packableItems, $underWeightBox->box);
+            if ($this->isEverythingPacked($newLighterBoxes, $packableItems) === false) {
                 continue; // only want to move this item if it still fits in a single box
             }
 
@@ -135,7 +136,7 @@ class WeightRedistributor implements LoggerAwareInterface
 
             unset($overWeightBoxItems[$key]);
             $newHeavierBoxes = $this->doVolumeRepack($overWeightBoxItems, $overWeightBox->box);
-            if (count($newHeavierBoxes) !== 1) {
+            if ($this->isEverythingPacked($newHeavierBoxes, $overWeightBoxItems) === false) {
                 assert(true, 'Could not pack n-1 items into box, even though n were previously in it');
                 continue;
             }
@@ -151,6 +152,20 @@ class WeightRedistributor implements LoggerAwareInterface
         }
 
         return $anyIterationSuccessful;
+    }
+
+    private function isEverythingPacked(PackedBoxList $result, array $expectedItems): bool
+    {
+        if ($result->count() !== 1) {
+            return false;
+        }
+
+        $packedItems = [];
+        foreach ($result->top()->items as $packedItem) {
+            $packedItems[] = $packedItem->item;
+        }
+
+        return count($packedItems) === count($expectedItems);
     }
 
     /**

--- a/src/WeightRedistributor.php
+++ b/src/WeightRedistributor.php
@@ -117,9 +117,8 @@ class WeightRedistributor implements LoggerAwareInterface
                 continue; // moving this item would harm more than help
             }
 
-            $packableItems = array_merge($underWeightBoxItems, [$overWeightItem]);
-            $newLighterBoxes = $this->doVolumeRepack($packableItems, $underWeightBox->box);
-            if ($this->isEverythingPacked($newLighterBoxes, $packableItems) === false) {
+            $newLighterBoxes = $this->doVolumeRepack(array_merge($underWeightBoxItems, [$overWeightItem]), $underWeightBox->box);
+            if ($newLighterBoxes->count() !== 1) {
                 continue; // only want to move this item if it still fits in a single box
             }
 
@@ -136,7 +135,7 @@ class WeightRedistributor implements LoggerAwareInterface
 
             unset($overWeightBoxItems[$key]);
             $newHeavierBoxes = $this->doVolumeRepack($overWeightBoxItems, $overWeightBox->box);
-            if ($this->isEverythingPacked($newHeavierBoxes, $overWeightBoxItems) === false) {
+            if (count($newHeavierBoxes) !== 1) {
                 assert(true, 'Could not pack n-1 items into box, even though n were previously in it');
                 continue;
             }
@@ -152,20 +151,6 @@ class WeightRedistributor implements LoggerAwareInterface
         }
 
         return $anyIterationSuccessful;
-    }
-
-    private function isEverythingPacked(PackedBoxList $result, array $expectedItems): bool
-    {
-        if ($result->count() !== 1) {
-            return false;
-        }
-
-        $packedItems = [];
-        foreach ($result->top()->items as $packedItem) {
-            $packedItems[] = $packedItem->item;
-        }
-
-        return count($packedItems) === count($expectedItems);
     }
 
     /**
@@ -184,7 +169,12 @@ class WeightRedistributor implements LoggerAwareInterface
         $packer->setBoxQuantity($currentBox, $this->boxQuantitiesAvailable[$currentBox] + 1);
         $packer->setItems($items);
 
-        return $packer->doBasicPacking(true);
+        $packedBoxes = $packer->doBasicPacking(true);
+        if ($packedBoxes->count() !== 1 || $packer->getUnpackedItems()->count() !== 0) {
+            return new PackedBoxList($this->packedBoxSorter);
+        }
+
+        return $packedBoxes;
     }
 
     /**

--- a/tests/WeightRedistributorTest.php
+++ b/tests/WeightRedistributorTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace DVDoug\BoxPacker;
 
 use DVDoug\BoxPacker\Test\ConstrainedPlacementNoStackingTestItem;
+use DVDoug\BoxPacker\Test\LimitedSupplyTestBox;
 use DVDoug\BoxPacker\Test\TestBox;
 use DVDoug\BoxPacker\Test\TestItem;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -66,5 +67,36 @@ class WeightRedistributorTest extends TestCase
         $packedBoxes = $packer->pack();
 
         self::assertEquals(0, $packedBoxes->getWeightVariance());
+    }
+
+    /**
+     * Test to ensure no items are silently dropped during weight redistribution.
+     */
+    public function testWeightRedistributionDoesNotSilentlyDropItems(): void
+    {
+        $packer = new Packer();
+        $packer->addBox(new LimitedSupplyTestBox('Box', 29, 29, 29, 0, 29, 29, 29, 68, 2));
+
+        $packer->addItem(new TestItem('Item 0', 10, 10, 10, 2, Rotation::BestFit), 2);
+        $packer->addItem(new TestItem('Item 1', 10, 10, 10, 3, Rotation::BestFit));
+        $packer->addItem(new TestItem('Item 2', 10, 10, 10, 4, Rotation::BestFit));
+        $packer->addItem(new TestItem('Item 3', 10, 10, 10, 8, Rotation::BestFit), 5);
+        $packer->addItem(new TestItem('Item 4', 10, 10, 10, 18, Rotation::BestFit), 3);
+
+        // packer initially packs 6 items into each box,
+        // the imbalance in weights will be attempted to be corrected by the WeightRedistributor
+        $packedBoxes = $packer->pack();
+        self::assertCount(2, $packedBoxes);
+
+        $packedItemCount = 0;
+        foreach ($packedBoxes as $packedBox) {
+            $packedItemCount += $packedBox->items->count();
+        }
+
+        self::assertSame(
+            12,
+            $packedItemCount + $packer->getUnpackedItems()->count(),
+            'No items should be lost during weight redistribution'
+        );
     }
 }


### PR DESCRIPTION
Fixes issue #665 by checking that the same number of items are packed after a repack in the weight redistributor